### PR TITLE
Breakpoints for FPPA

### DIFF
--- a/src/sims/pdk.src/pdk.cc
+++ b/src/sims/pdk.src/pdk.cc
@@ -103,6 +103,9 @@ int cl_fpp::init(void) {
       n.format("PC%d", id);
       d.format("Program counter of FPP%d", id);
       puc->mk_cvar(&cPC, n, d);
+
+      delete fbrk;
+      fbrk = puc->fbrk;
     }
   
   return (0);


### PR DESCRIPTION
How can I set code breakpoints on PDK controllers?
When I set a breakpoint, it is saved in the parent uc. And FPAAs are running without any breakpoints.
I have attached a suggestion that might work. FPPAs use the same breakpoints as their parent.